### PR TITLE
Added Swedish (sv) translation

### DIFF
--- a/nls/sv/Strings.js
+++ b/nls/sv/Strings.js
@@ -1,0 +1,34 @@
+define( {
+	// EXTENSION.
+	EXTENSION_NAME: "SFTP Upload",
+    
+    // MENUS
+    UPLOAD_MENU_NAME: "Ladda upp via SFTP",
+    DOWNLOAD_MENU_NAME: "Ladda ner från server",
+	
+	// GENERAL.
+	YES:    "Ja",
+	NO:     "Nej",
+	OK:     "Ok",
+	CANCEL: "Avbryt",
+	UPLOAD: "Ladda upp",
+	SKIP:   "Hoppa över",
+	
+	// TOOLBAR.
+	SERVER_SETUP: "Serverinställningar",
+	UPLOAD_ALL: "Ladda upp allt",
+	SKIP_ALL: "Hoppa över allt",
+	
+	// SETTINGS DIALOG.
+	SETTINGS_DIALOG_TITLE:        "SFTP inställningar",
+	SETTINGS_DIALOG_TYPE:    	  "Typ",
+	SETTINGS_DIALOG_TYPE_FTP: 	  "FTP",
+	SETTINGS_DIALOG_TYPE_SFTP:    "Sftp(SSH)",
+	SETTINGS_DIALOG_HOST: 		  "Värd",
+	SETTINGS_DIALOG_PORT: 		  "Port",
+	SETTINGS_DIALOG_USERNAME: 	  "Användarnamn",
+	SETTINGS_DIALOG_PASSWORD: 	  "Lösenord",
+    SETTINGS_DIALOG_RSAMSG:       "RSA nyckelsökväg",
+	SETTINGS_DIALOG_PATH: 		  "Sökväg",
+    SETTINGS_UPLOAD_ON_SAVE:      "Ladda upp efter spara"
+} );


### PR DESCRIPTION
The plugin did not work without the translation, and console mentioned a "file not found" error.